### PR TITLE
CYC-67 Add Inventory item model

### DIFF
--- a/app/Models/InventoryItem.php
+++ b/app/Models/InventoryItem.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class InventoryItem extends Model
+{
+    use HasFactory;
+}

--- a/database/factories/InventoryItemFactory.php
+++ b/database/factories/InventoryItemFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\InventoryItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class InventoryItemFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = InventoryItem::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->word,
+            'description' => $this->faker->text,
+            'cost' => $this->faker->randomFloat(2, 0, 10000),
+            'sale_price' => $this->faker->randomFloat(2, 0, 10000),
+            'stock' => $this->faker->randomDigit,
+            'category' => $this->faker->word,
+            'size' => $this->faker->word,
+            'color' => $this->faker->colorName,
+            'finish' => $this->faker->word,
+            'material' => $this->faker->word,
+            'part_number' => $this->faker->shuffle('abcdefghigj1234567891234567')
+        ];
+    }
+}

--- a/database/migrations/2021_02_09_234352_create_inventory_items_table.php
+++ b/database/migrations/2021_02_09_234352_create_inventory_items_table.php
@@ -27,6 +27,8 @@ class CreateInventoryItemsTable extends Migration
             $table->string('finish')->nullable();
             $table->string('material')->nullable();
             $table->string('part_number')->nullable();
+            $table->float('lead_time')->nullable();
+            $table->float('labour_cost')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2021_02_09_234352_create_inventory_items_table.php
+++ b/database/migrations/2021_02_09_234352_create_inventory_items_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateInventoryItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('inventory_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('supplier_id')->nullable();
+            $table->string('title');
+            $table->text('description');
+            $table->float('cost');
+            $table->float('sale_price');
+            $table->integer('stock')->default(0);
+            $table->string('category')->nullable();
+            $table->string('size')->nullable();
+            $table->string('color')->nullable();
+            $table->string('finish')->nullable();
+            $table->string('material')->nullable();
+            $table->string('part_number')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('inventory_items');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use Database\Factories\InventoryItemFactory;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,6 +14,14 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
+        // Always create the same user every time for testing purposes
+        \App\Models\User::create([
+            'name' => "Example User",
+            'email' => "user@example.com",
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+        ]);
+         \App\Models\User::factory(10)->create();
+         \App\Models\InventoryItem::factory(25)->create();
     }
 }


### PR DESCRIPTION
## Description 
Closes #52 
See [CYC-67](https://soen390team13.atlassian.net/browse/CYC-67)
Adds a basic `InventoryItem` Model along with associated migration and factory. Stubs out relation with supplier, to be added later. 

## Changes
- Adds `InventoryItem` model
- Adds `InventoryItem` migration with fields mentioned in #52
- Adds `InventoryItemFactory` to generate items on the fly
- Registers factories in default seeder
  - includes `User` and `InventoryItem` factories
  - also adds a "default user" on seed `user@example.com` / `password`

_nb:_ all seeded users also have their password set to: `password`.