### PR TITLE
CYC-70 Add store BOM controller function

### DIFF
--- a/app/Http/Controllers/MaterialController.php
+++ b/app/Http/Controllers/MaterialController.php
@@ -2,7 +2,10 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\BillOfMaterial;
+use App\Models\InventoryItem;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class MaterialController extends Controller
 {
@@ -34,7 +37,24 @@ class MaterialController extends Controller
      */
     public function store(Request $request)
     {
-        //
+        $assemblyId = $request->assembly_id;
+        $materialIds = $request->material_ids;
+        $pairs = collect();
+
+        if(is_string($materialIds)) {
+            $materialIds = trim($materialIds," ,");
+            $materialIds = Str::contains($materialIds, ",") ? explode(",", $materialIds) : [$materialIds];
+        }
+
+        foreach($materialIds as $id) {
+            $pairs->push([
+                'assembly_id' => $assemblyId,
+                'material_id' => trim($id),
+            ]);
+        }
+
+        BillOfMaterial::insert($pairs->toArray());
+        return InventoryItem::find($assemblyId)->materials;
     }
 
     /**

--- a/app/Models/BillOfMaterial.php
+++ b/app/Models/BillOfMaterial.php
@@ -9,5 +9,6 @@ class BillOfMaterial extends Model
 {
     use HasFactory;
 
+    protected $guarded = ['id'];
 
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,8 @@ use App\Http\Controllers\MaterialController;
 
 require __DIR__.'/auth.php';
 
-Route::post('/material', [MaterialController::class, "store"]);
+Route::post('/material', [MaterialController::class, "store"])
+    ->middleware(['auth']);
 
 Route::put('/inventory/{id}', [InventoryItemController::class, "update"]);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\InventoryItemController;
+use App\Http\Controllers\MaterialController;
 
 /*
 |--------------------------------------------------------------------------
@@ -15,6 +16,8 @@ use App\Http\Controllers\InventoryItemController;
 */
 
 require __DIR__.'/auth.php';
+
+Route::post('/material', [MaterialController::class, "store"]);
 
 Route::put('/inventory/{id}', [InventoryItemController::class, "update"]);
 


### PR DESCRIPTION
## Description
Creates MaterialController class with a store function to insert material items to assemblies
Closes #51 

## Changes
* Create `MaterialController.php`
* Add `store` function to material controller
* Add route to `web.php` for store function.
* Modified `BillOfMaterial` model to guard id.

## Specifications
* Possible inputs pairs: 
    * assembly_id: single integer, material_ids: single integer
    * assembly_id: single integer, material_ids: comma separated list of integers
    * assembly_id: single integer, material_ids: array of integers