### PR TITLE
CYC-68 Add Destroy Inventory Controller function

### DIFF
--- a/app/Http/Controllers/InventoryItemController.php
+++ b/app/Http/Controllers/InventoryItemController.php
@@ -63,4 +63,16 @@ class InventoryItemController extends Controller
 
         return $inventoryItem->refresh();
     }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        $inventoryItem = InventoryItem::findOrFail($id);
+        $inventoryItem->delete();
+    }
 }

--- a/database/migrations/2021_02_10_010234_create_bill_of_materials_table.php
+++ b/database/migrations/2021_02_10_010234_create_bill_of_materials_table.php
@@ -15,8 +15,8 @@ class CreateBillOfMaterialsTable extends Migration
     {
         Schema::create('bill_of_materials', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('assembly_id')->references('id')->on('inventory_items');
-            $table->foreignId('material_id')->references('id')->on('inventory_items');
+            $table->foreignId('assembly_id')->references('id')->on('inventory_items')->onDelete('cascade');
+            $table->foreignId('material_id')->references('id')->on('inventory_items')->onDelete('cascade');
             $table->timestamps();
 
             $table->unique(['assembly_id', 'material_id']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,11 @@ Route::post('/material', [MaterialController::class, "store"])
 Route::put('/inventory/{id}', [InventoryItemController::class, "update"])
     ->middleware(['auth']);
 
-Route::get('/materials/{id}', [MaterialController::class, "show"])->middleware(['auth']);
+Route::delete('/inventory/{id}', [InventoryItemController::class, "destroy"])
+    ->middleware(['auth']);
+
+Route::get('/materials/{id}', [MaterialController::class, "show"])
+    ->middleware(['auth']);
 
 Route::get('/token', function () {
     if(config("app.debug")){


### PR DESCRIPTION
## Description
Creates a destroy function in 'InventoryItemController' which allows the cascading deletion of InventoryItem and BillOfMaterial entries
Closes #66 

## Changes
* Add `destroy` function to `InventoryItemController`
* Add route to `web.php` for `destroy` function.
* Modified migrations to allow cascading deletion for the bill of material table