### PR TITLE
CYC-62 Add inventory index route with search capabilities

### DIFF
--- a/app/Http/Controllers/InventoryItemController.php
+++ b/app/Http/Controllers/InventoryItemController.php
@@ -11,6 +11,40 @@ use Illuminate\Http\Request;
  */
 class InventoryItemController extends Controller
 {
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $items = InventoryItem::query();
+        if ($request->q) {
+            $items = $items
+                ->where("title", "like", "%{$request->q}%")
+                ->orWhere("Description", "like", "%{$request->q}%");
+        }
+
+        $filters = $request->only([
+            "size",
+            "color",
+            "category",
+            "cost",
+            "sale_price",
+            "material",
+            "finish",
+            "labour_cost"
+        ]);
+
+        if ($filters) {
+            foreach ($filters as $filter => $value) {
+                $items = $items->where($filter, $value);
+            }
+        }
+        return $items->get();
+    }
+
     /**
      * update
      * Updates inventory item information on put request.

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,7 +20,8 @@ require __DIR__.'/auth.php';
 Route::post('/material', [MaterialController::class, "store"])
     ->middleware(['auth']);
 
-Route::get('/inventory', [InventoryItemController::class, "index"]);
+Route::get('/inventory', [InventoryItemController::class, "index"])
+    ->middleware(['auth']);
 
 Route::put('/inventory/{id}', [InventoryItemController::class, "update"])
     ->middleware(['auth']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,8 @@ require __DIR__.'/auth.php';
 Route::post('/material', [MaterialController::class, "store"])
     ->middleware(['auth']);
 
+Route::get('/inventory', [InventoryItemController::class, "index"]);
+
 Route::put('/inventory/{id}', [InventoryItemController::class, "update"])
     ->middleware(['auth']);
 


### PR DESCRIPTION
## Description
Closes #72 
[See CYC-62](https://soen390team13.atlassian.net/browse/CYC-62)
Adds a `/inventory` GET route that allows for filtering of index items via the query parameters.

you can pass `q` in the query string for fuzzy search on titles or description
or you can pass  any of the following to filter exactly. 
```
[
   "size",
   "color",
   "category",
   "cost",
   "sale_price",
   "material",
   "finish",
   "labour_cost"
]
```

## Changes
- Adds a index function to the `InventoryItemController`
   - Accepts Query parameters described above to allow for filtering of returned results
- Add route to `web.php`, to `/inventory` as a GET request.

## Testing 
If you are attempting to test this PR, you will need a REST client, like Insomnia. Postman also works.

Create a new request and format it like so: 
![image](https://user-images.githubusercontent.com/9440691/108663050-a4e39d80-749d-11eb-92b5-68ad37d24e81.png)

You can experiment with values in the "Query" tab as out lined above to ensure the filters listed work correctly.
