### PR TITLE
CYC-107 CYC-110 Add Purchase Order and Orderables Models

### DIFF
--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class OrderItem extends Model
+{
+    use HasFactory;
+
+    public function purchase_orders()
+    {
+        return $this->morphedByMany(PurchaseOrder::class, 'orderable');
+    }
+}

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -4,12 +4,15 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class OrderItem extends Model
 {
     use HasFactory;
 
-    public function purchase_orders()
+    protected $table = 'orderables';
+
+    public function purchase_orders() : MorphToMany
     {
         return $this->morphedByMany(PurchaseOrder::class, 'orderable');
     }

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PurchaseOrder extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    public function order_items()
+    {
+        return $this->morphToMany(InventoryItem::class, 'orderable');
+    }
+}

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 class PurchaseOrder extends Model
 {
@@ -11,7 +12,7 @@ class PurchaseOrder extends Model
 
     protected $guarded = ['id'];
 
-    public function order_items()
+    public function order_items() : MorphToMany
     {
         return $this->morphToMany(InventoryItem::class, 'orderable');
     }

--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -27,6 +27,10 @@ class Supplier extends Model
         return $now->isBefore($this->partnership_end_date) && $now->isAfter($this->partnership_start_date);
     }
 
+    /**
+     * scope query that allows for pulling all valid partnerships
+     * @return mixed
+     */
     public function scopeHasValidPartnership()
     {
         $now = now()->format('Y-m-d');

--- a/database/factories/PurchaseOrderFactory.php
+++ b/database/factories/PurchaseOrderFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PurchaseOrder;
+use App\Models\Supplier;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PurchaseOrderFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = PurchaseOrder::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'supplier_id' => Supplier::inRandomOrder()->first(),
+            'delivery_date' => $this->faker->dateTimeBetween('now', '+3 months'),
+            'status' => $this->faker->word
+        ];
+    }
+}

--- a/database/migrations/2021_03_03_224040_create_purchase_orders_table.php
+++ b/database/migrations/2021_03_03_224040_create_purchase_orders_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePurchaseOrdersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('purchase_orders', function (Blueprint $table) {
+            $table->id();
+//            $table->foreign('inventory_item_id')->references('id')->on('inventory_items');
+            $table->foreignId('supplier_id')->references('id')->on('suppliers');
+            $table->string('status');
+            $table->timestamp('delivery_date');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('purchase_orders');
+    }
+}

--- a/database/migrations/2021_03_03_224820_create_orderables_table.php
+++ b/database/migrations/2021_03_03_224820_create_orderables_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateOrderablesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('orderables', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('orderable');
+            $table->foreignId('inventory_item_id')->references('id')->on('inventory_items');
+            $table->integer('quantity')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('orderables');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\InventoryItem;
+use App\Models\PurchaseOrder;
 use App\Models\Supplier;
 use App\Models\User;
 use Illuminate\Database\Seeder;
@@ -27,5 +28,7 @@ class DatabaseSeeder extends Seeder
          User::factory(10)->create();
         Supplier::factory(5)->create();
         InventoryItem::factory(25)->create();
+        PurchaseOrder::factory(5)->create();
+        $this->call(OrderableSeeder::class);
     }
 }

--- a/database/seeders/OrderableSeeder.php
+++ b/database/seeders/OrderableSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\InventoryItem;
+use App\Models\PurchaseOrder;
+use Illuminate\Database\Seeder;
+
+class OrderableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        foreach (PurchaseOrder::all() as $purchaseOrder) {
+            $randomItems = [];
+            for ($i = 0; $i < rand(1, 10); $i++) {
+                $randomItems[] = ['inventory_item_id' => InventoryItem::inRandomOrder()->first()->id, 'quantity' => rand(0, 30)];
+            }
+            $purchaseOrder->order_items()->sync($randomItems);
+        }
+    }
+}


### PR DESCRIPTION
~~**Important:** #95 should be reviewed and merged **before** this PR~~ Merged!

## Description 
Closes #93 
Closes #94 
See [CYC-107](https://soen390team13.atlassian.net/browse/CYC-107) & [CYC-110](https://soen390team13.atlassian.net/browse/CYC-110)

Adds both the Purchase Order and Order Item / Orderable polymorphic pivots. This allows for creating purchase orders to suppliers and to list `InventoryItem`s as line items in the purchase order

## Changes 
- Add purchase_orders migration
- Add orderables migration
- Add `PurchaseOrder` model
- Add `OrderItem` polymorphic pivot model
- Add `PurchaseOrder` Factory
- Add Orderable seeder to attach items to purchase orders