### PR TITLE
CYC-111 Add Update function to PurchaseOrderController

### DIFF
--- a/app/Http/Controllers/PurchaseOrderItemController.php
+++ b/app/Http/Controllers/PurchaseOrderItemController.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\InventoryItem;
+use App\Models\PurchaseOrder;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Str;
+
+class PurchaseOrderItemController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        try {
+            $request->validate([
+                'item_ids' => "required"
+            ]);
+        } catch (ValidationException $e) {
+            return response([
+                'success' => false,
+                'errors' => $e->errors()
+            ]);
+        }
+
+        $itemIds = $request->item_ids;
+
+        if (is_string($itemIds)) {
+            $itemIds = trim($itemIds, " ,");
+            $itemIds = Str::contains($itemIds, ",") ? explode(",", $itemIds) : [$itemIds];
+        }
+
+        $items = InventoryItem::findMany($itemIds);
+
+        $purchaseOrder = PurchaseOrder::findOrFail($id);
+
+        $purchaseOrder->order_items()->sync($items);
+        $purchaseOrder->save();
+
+        return response([
+            'success' => true,
+            'data' => $purchaseOrder->refresh()->order_items
+        ]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\MaterialController;
 use App\Http\Controllers\UserRoleController;
 use App\Http\Controllers\RoleController;
 use App\Http\Controllers\SupplierItemController;
+use App\Http\Controllers\PurchaseOrderItemController;
 
 /*
 |--------------------------------------------------------------------------
@@ -19,6 +20,8 @@ use App\Http\Controllers\SupplierItemController;
 */
 
 require __DIR__.'/auth.php';
+
+Route::put('/purchase-order/orderables/{id}', [PurchaseOrderItemController::class, "update"])->middleware(['auth']);
 
 Route::post('/supplier/items', [SupplierItemController::class, "store"])->middleware(['auth']);
 

--- a/tests/Feature/PurchaseOrderItemTest.php
+++ b/tests/Feature/PurchaseOrderItemTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\PurchaseOrder;
+use App\Models\Supplier;
+use App\Models\InventoryItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class PurchaseOrderItemTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     *
+     * @test
+     * @return void
+     */
+    public function test_items_can_be_updated()
+    {
+        $user = User::first();
+        $attached = $this->actingAs($user)->put('/purchase-order/orderables/1', [
+            'item_ids' => [19, 20]
+        ]);
+
+        $expectedItems = InventoryItem::findMany([19, 20]);
+
+        $attachedData = $attached->getOriginalContent();
+
+        $pivotData = $attachedData['data'];
+
+        $this->assertCount(2, $pivotData);
+
+        $actualItems = InventoryItem::findMany([$pivotData[0]->id, $pivotData[1]->id]);
+
+        $attached->assertStatus(200);
+        $this->assertTrue($attachedData['success']);
+        $this->assertEquals($expectedItems, $actualItems);
+    }
+}

--- a/tests/Feature/PurchaseOrderItemTest.php
+++ b/tests/Feature/PurchaseOrderItemTest.php
@@ -20,7 +20,7 @@ class PurchaseOrderItemTest extends TestCase
      * @test
      * @return void
      */
-    public function test_items_can_be_updated()
+    public function test_items_can_be_updated_with_array()
     {
         $user = User::first();
         $attached = $this->actingAs($user)->put('/purchase-order/orderables/1', [
@@ -28,6 +28,33 @@ class PurchaseOrderItemTest extends TestCase
         ]);
 
         $expectedItems = InventoryItem::findMany([19, 20]);
+
+        $attachedData = $attached->getOriginalContent();
+
+        $pivotData = $attachedData['data'];
+
+        $this->assertCount(2, $pivotData);
+
+        $actualItems = InventoryItem::findMany([$pivotData[0]->id, $pivotData[1]->id]);
+
+        $attached->assertStatus(200);
+        $this->assertTrue($attachedData['success']);
+        $this->assertEquals($expectedItems, $actualItems);
+    }
+
+    /**
+     *
+     * @test
+     * @return void
+     */
+    public function test_items_can_be_updated_with_string()
+    {
+        $user = User::first();
+        $attached = $this->actingAs($user)->put('/purchase-order/orderables/1', [
+            'item_ids' => "17,18"
+        ]);
+
+        $expectedItems = InventoryItem::findMany([17, 18]);
 
         $attachedData = $attached->getOriginalContent();
 


### PR DESCRIPTION
## Description
Adds endpoint that allows modifying purchase order to inventory item relationships.
Closes #104 

## Changes
- Creates PurchaseOrderController
- Defines update function on PurchaseOrderController
- Adds put endpoint to web.php router at `/purchase-order/orderables/{id}`
- Adds PurchaseOrderItemTest.php