### PR TITLE
 CYC-116 Add Observer, Auto order inventory when below min_stock

### DIFF
--- a/app/Http/Controllers/InventoryItemController.php
+++ b/app/Http/Controllers/InventoryItemController.php
@@ -115,12 +115,7 @@ class InventoryItemController extends Controller
         ]);
 
         //updating the belongsTo relationship of the supplier
-        $supplier_id = $request->supplier_id;
-        if (!is_null($supplier_id)) {
-            $inventoryItem->supplier()->associate($supplier_id);
-            $inventoryItem->save();
-        }
-
+        $params['supplier_id'] = $request->supplier_id ?? $inventoryItem->supplier_id;
         $inventoryItem->update($params);
 
         return response([

--- a/app/Observers/InventoryItemObserver.php
+++ b/app/Observers/InventoryItemObserver.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\InventoryItem;
+use App\Models\OrderItem;
+use App\Models\PurchaseOrder;
+
+class InventoryItemObserver
+{
+    /**
+     * Handle the InventoryItem "created" event.
+     *
+     * @param  \App\Models\InventoryItem  $inventoryItem
+     * @return void
+     */
+    public function created(InventoryItem $inventoryItem)
+    {
+        //
+    }
+
+    /**
+     * Handle the InventoryItem "updated" event.
+     *
+     * @param  \App\Models\InventoryItem  $inventoryItem
+     * @return void
+     */
+    public function updated(InventoryItem $inventoryItem)
+    {
+        //Check if item is below stock
+        if($inventoryItem->getIsBelowMinimumAttribute())
+        {
+            //Check if there is an existing order for said inventory item
+            if(!OrderItem::where('inventory_item_id',$inventoryItem->id)->exists())
+            {
+                //Create purchase order to specified supplier
+                $purchaseOrder = PurchaseOrder::create([
+                    'supplier_id' => $inventoryItem->supplier_id,
+                    'status' => "pending",
+                ]);
+
+                $purchaseOrder->save();
+
+
+                //Create orderables for the created purchase order
+                $orderItem = OrderItem::create([
+                    'orderable_type' => 'App\Models\PurchaseOrder',
+                    'orderable_id' => $purchaseOrder->id,
+                    'inventory_item_id' => $inventoryItem->id,
+                    'quantity' => $inventoryItem->minimum_stock +15,
+                ]);
+
+                $orderItem->save();
+            }
+        }
+    }
+
+    /**
+     * Handle the InventoryItem "deleted" event.
+     *
+     * @param  \App\Models\InventoryItem  $inventoryItem
+     * @return void
+     */
+    public function deleted(InventoryItem $inventoryItem)
+    {
+        //
+    }
+
+    /**
+     * Handle the InventoryItem "restored" event.
+     *
+     * @param  \App\Models\InventoryItem  $inventoryItem
+     * @return void
+     */
+    public function restored(InventoryItem $inventoryItem)
+    {
+        //
+    }
+
+    /**
+     * Handle the InventoryItem "force deleted" event.
+     *
+     * @param  \App\Models\InventoryItem  $inventoryItem
+     * @return void
+     */
+    public function forceDeleted(InventoryItem $inventoryItem)
+    {
+        //
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\InventoryItem;
 use App\Models\PurchaseOrder;
+use App\Observers\InventoryItemObserver;
 use App\Observers\PurchaseOrderObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -30,5 +32,6 @@ class EventServiceProvider extends ServiceProvider
     public function boot()
     {
         PurchaseOrder::observe(PurchaseOrderObserver::class);
+        InventoryItem::observe(InventoryItemObserver::class);
     }
 }

--- a/database/factories/InventoryItemFactory.php
+++ b/database/factories/InventoryItemFactory.php
@@ -28,7 +28,7 @@ class InventoryItemFactory extends Factory
             'description' => $this->faker->text,
             'cost' => $this->faker->randomFloat(2, 0, 10000),
             'sale_price' => $this->faker->randomFloat(2, 0, 10000),
-            'stock' => $this->faker->randomDigit,
+            'stock' => $this->faker->numberBetween(1,9),
             'category' => $this->faker->word,
             'size' => $this->faker->word,
             'color' => $this->faker->colorName,

--- a/database/migrations/2021_03_03_224040_create_purchase_orders_table.php
+++ b/database/migrations/2021_03_03_224040_create_purchase_orders_table.php
@@ -17,7 +17,7 @@ class CreatePurchaseOrdersTable extends Migration
             $table->id();
             $table->foreignId('supplier_id')->references('id')->on('suppliers');
             $table->string('status');
-            $table->timestamp('delivery_date');
+            $table->timestamp('delivery_date')->nullable();
             $table->timestamps();
         });
     }

--- a/tests/Feature/InventoryTest.php
+++ b/tests/Feature/InventoryTest.php
@@ -128,7 +128,8 @@ class InventoryTest extends TestCase
             'description' => "This items will be a test item",
             'cost' => 9.99,
             'sale_price' => 19.99,
-            'size' => "testSize"
+            'size' => "testSize",
+            'supplier_id'=>2,
         ]);
 
         // make sure we're redirected
@@ -138,14 +139,13 @@ class InventoryTest extends TestCase
 
         $redirected->assertStatus(302);
 
-
         // check that items get updated properly
         $user = User::first();
         $updated = $this->actingAs($user)->put("/inventory/$itemA->id", [
-            'title' => "this is a new title"
+            'title' => "this is a new title",
         ]);
-        $updatedData = $updated->getOriginalContent();
 
+        $updatedData = $updated->getOriginalContent();
         $updated->assertStatus(200);
         $this->assertNotEquals($itemA, $updatedData['data']);
         $this->assertEquals("this is a new title", $updatedData['data']->title);

--- a/tests/Unit/InventoryItemObserverTest.php
+++ b/tests/Unit/InventoryItemObserverTest.php
@@ -4,7 +4,6 @@ namespace Tests\Unit;
 
 use App\Models\OrderItem;
 use App\Models\PurchaseOrder;
-use App\Models\User;
 use App\Models\InventoryItem;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;

--- a/tests/Unit/InventoryItemObserverTest.php
+++ b/tests/Unit/InventoryItemObserverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\OrderItem;
+use App\Models\PurchaseOrder;
+use App\Models\User;
+use App\Models\InventoryItem;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class InventoryItemObserverTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * Testing the auto order functionality on inventory item update
+     *
+     * @return void
+     */
+    public function test_minimum_stock_auto_order()
+    {
+        $item = InventoryItem::create([
+            'title' => "observer test",
+            'description' => "This ites will be a test item",
+            'cost' => 9.99,
+            'sale_price' => 19.99,
+            'supplier_id' => 4,
+            'minimum_stock' => 4,
+            'stock'=>8,
+        ]);
+        $item->save();
+
+        //Verifying count of purchase orders and orderables before updating inventory
+        $purchaseOrdersBefore = PurchaseOrder::count();
+        $orderablesBefore = OrderItem::count();
+
+        //Demonstrating orderable does not exist before updating inventory item
+        $this->assertNotEquals(OrderItem::where('inventory_item_id',$item->id)->exists(), true);
+
+        //Triggering the InventoryItemObserver by updating an inventory item
+        $item->stock = 1;
+        $item->save();
+
+        //Did it work? Have PurchaseOrder and Orderables table been updated?
+        $this->assertEquals($purchaseOrdersBefore+1, PurchaseOrder::count());
+        $this->assertEquals($orderablesBefore+1, OrderItem::count());
+        $this->assertEquals(OrderItem::where('inventory_item_id',$item->id)->exists(), true);
+    }
+}


### PR DESCRIPTION
## Description
[CYC-116](https://soen390team13.atlassian.net/browse/CYC-116?atlOrigin=eyJpIjoiMzU2NmNkMDBmOTQ0NGY5ZjljZDRiMmJlMTdiNGUyNGYiLCJwIjoiaiJ9)
Closes #128 
Added a `InventoryItemObserver` which manages the auto-ordering of inventory items when `stock` falls below specified `minimum_stock`.

## Changes
- Added  `InventoryItemObserver` 
- Added appropriate function to handle auto-ordering on `InventoryItem` update
- Added relevant tests for the `InventoryItemObserver`