### PR TITLE
CYC-130 Add CSV Report generator and download endpoint

### DIFF
--- a/app/Actions/GenerateStockCSVAction.php
+++ b/app/Actions/GenerateStockCSVAction.php
@@ -8,7 +8,7 @@ use App\Models\InventoryItem;
 
 class GenerateStockCSVAction
 {
-    public function __invoke() : string
+    public function execute() : string
     {
         $lowStock = InventoryItem::with('supplier')->belowMinimum()->get();
         $rows = $lowStock->map(function ($item) {

--- a/app/Actions/GenerateStockCSVAction.php
+++ b/app/Actions/GenerateStockCSVAction.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace App\Actions;
+
+
+use App\Models\InventoryItem;
+
+class GenerateStockCSVAction
+{
+    public function __invoke() : string
+    {
+        $lowStock = InventoryItem::with('supplier')->belowMinimum()->get();
+        $rows = $lowStock->map(function ($item) {
+            $row = $item->only(['title', 'cost', 'stock', 'minimum_stock']);
+            $row[] = $item->supplier->name;
+            return implode(",", $row);
+        });
+        $rows->prepend('Title,Cost,Current Stock,Minimum Stock,Supplier Name');
+        return $rows->implode(PHP_EOL);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,8 +2,11 @@
 
 namespace App\Console;
 
+use App\Mail\StockReport;
+use App\Models\User;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Mail;
 
 class Kernel extends ConsoleKernel
 {
@@ -24,7 +27,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->call(function () {
+            $recipients = User::where('role', 'admin')->get()->pluck('email');
+            Mail::to($recipients)->send(new StockReport());
+        })->daily();
     }
 
     /**

--- a/app/Http/Controllers/StockReportController.php
+++ b/app/Http/Controllers/StockReportController.php
@@ -14,7 +14,7 @@ class StockReportController extends Controller
         $storage = Storage::disk('public');
         $filename = now()->format('Y-m-d-His')."_stock_report.csv";
         $storage->put($filename, (new GenerateStockCSVAction())->execute());
-        
+
         return response()->download($storage->path($filename));
     }
 }

--- a/app/Http/Controllers/StockReportController.php
+++ b/app/Http/Controllers/StockReportController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Actions\GenerateStockCSVAction;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class StockReportController extends Controller
+{
+    public function show()
+    {
+        $storage = Storage::disk('public');
+        $filename = now()->format('Y-m-d-His')."_stock_report.csv";
+        $storage->put($filename, (new GenerateStockCSVAction())->execute());
+        
+        return response()->download($storage->path($filename));
+    }
+}

--- a/app/Mail/StockReport.php
+++ b/app/Mail/StockReport.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class StockReport extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('view.name');
+    }
+}

--- a/app/Mail/StockReport.php
+++ b/app/Mail/StockReport.php
@@ -2,10 +2,13 @@
 
 namespace App\Mail;
 
+use App\Actions\GenerateStockCSVAction;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
 
 class StockReport extends Mailable
 {
@@ -28,6 +31,11 @@ class StockReport extends Mailable
      */
     public function build()
     {
-        return $this->view('view.name');
+        $storage = Storage::disk('public');
+        $filename = now()->format('Y-m-d-His')."_stock_report.csv";
+        $storage->put($filename, (new GenerateStockCSVAction())->execute());
+        return $this->view("emails.stock.report_plain")
+            ->from('no-reply@cycl.io')
+            ->attach($storage->path($filename));
     }
 }

--- a/resources/views/emails/stock/report_plain.blade.php
+++ b/resources/views/emails/stock/report_plain.blade.php
@@ -1,0 +1,3 @@
+This is an automated message. You are receiving this message because you are an admin on Cycl.io.
+
+Attached is a report detailing the inventory items that are below their minimum stock.

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\RoleController;
 use App\Http\Controllers\SupplierController;
 use App\Http\Controllers\SupplierItemController;
 use App\Http\Controllers\PurchaseOrderItemController;
+use App\Http\Controllers\StockReportController;
 
 /*
 |--------------------------------------------------------------------------
@@ -47,6 +48,8 @@ Route::post('/user/roles', [UserRoleController::class, 'store'])->middleware(['a
 Route::delete('/user/roles', [UserRoleController::class, 'destroy'])->middleware(['auth']);
 
 Route::post('/roles', [RoleController::class, 'store'])->middleware(['auth']);
+
+Route::get('/stock/report', [StockReportController::class, 'show'])->middleware(['auth']);
 
 Route::get('/token', function () {
     if(config("app.debug")){

--- a/tests/Feature/StockReportTest.php
+++ b/tests/Feature/StockReportTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\GenerateStockCSVAction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Tests\TestCase;
+
+class StockReportTest extends TestCase
+{
+
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function test_report_is_downloaded()
+    {
+        $user = User::first();
+        $response = $this->actingAs($user)->get('/stock/report');
+        $file = $response->getFile();
+
+        $this->assertFileExists($file->getPathname());
+        $response->assertStatus(200);
+
+        // clean up
+        Storage::disk('public')->delete($file->getBasename());
+    }
+}


### PR DESCRIPTION
## Description
Closes #130 
See [CYC-123](https://soen390team13.atlassian.net/browse/CYC-123)

Adds a scheduled task that sends an email every day at midnight, as well as an endpoint that generates a CSV report containing information about all stock items that are below their minimum stock.

## Changes 
- Add Action the generates CSV text
- Add mailer for generating and sending an email with a CSV report attached
- Add an endpoint that allows generating and downloading a report at will
- Add a basic view containing the text to be sent in the email