### PR TITLE
CYC-137 Add Filter to Purchase Order Controller Index Function

### DIFF
--- a/tests/Feature/PurchaseOrderTest.php
+++ b/tests/Feature/PurchaseOrderTest.php
@@ -138,9 +138,6 @@ class PurchaseOrderTest extends TestCase
         $index = $this->actingAs($user)->get('/purchase-order?supplier_id=1');
         $indexData = $index->getOriginalContent();
 
-        //dd($indexData['data']);
-
-
         $index->assertStatus(200);
         $this->assertTrue($indexData['success']);
         foreach ($indexData['data'] as $order)

--- a/tests/Feature/PurchaseOrderTest.php
+++ b/tests/Feature/PurchaseOrderTest.php
@@ -132,6 +132,20 @@ class PurchaseOrderTest extends TestCase
         $this->assertCount(PurchaseOrder::count(), $indexData['data']);
     }
 
+    public function test_purchase_orders_can_be_indexed_with_filter()
+    {
+        $user = User::first();
+        $index = $this->actingAs($user)->get('/purchase-order?supplier_id=1');
+        $indexData = $index->getOriginalContent();
+
+        //dd($indexData['data']);
+
+
+        $index->assertStatus(200);
+        $this->assertTrue($indexData['success']);
+        foreach ($indexData['data'] as $order)
+            $this->assertEquals('1', $order->supplier_id);
+    }
 
     public function test_purchase_order_can_be_shown()
     {


### PR DESCRIPTION
## Description
- Add request body to index function and handle filter
- Closes #151 

## Changes
- Add filter handling to index function in PurchaseOrderController
- Add test case test_purchase_orders_can_be_indexed_with_filter to PurchaseOrderTest.php