### PR TITLE
CYC-156 Refactor sale and purchase order statuses

### DIFF
--- a/app/Http/Controllers/PurchaseOrderController.php
+++ b/app/Http/Controllers/PurchaseOrderController.php
@@ -15,7 +15,7 @@ class PurchaseOrderController extends Controller
      */
     public function index(Request $request)
     {
-        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED;
+        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED . "," . PurchaseOrder::PAID;
         try {
             // validate that the incoming data is correct
             $request->validate([
@@ -57,7 +57,7 @@ class PurchaseOrderController extends Controller
     public function store(Request $request)
     {
         // create a list of possible statuses
-        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED;
+        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED . "," . PurchaseOrder::PAID;
         try {
             // validate the data to be stored is correct
             $request->validate([
@@ -113,7 +113,7 @@ class PurchaseOrderController extends Controller
     public function update(Request $request, $id)
     {
         // create a list of possible statuses
-        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED;
+        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED . "," . PurchaseOrder::PAID;
         try {
             // validate that the incoming data is correct
             $request->validate([

--- a/app/Http/Controllers/PurchaseOrderController.php
+++ b/app/Http/Controllers/PurchaseOrderController.php
@@ -15,7 +15,7 @@ class PurchaseOrderController extends Controller
      */
     public function index(Request $request)
     {
-        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED . "," . PurchaseOrder::PAID;
+        $statuses = $this->getPurchaseOrderStatuses();
         try {
             // validate that the incoming data is correct
             $request->validate([
@@ -57,7 +57,7 @@ class PurchaseOrderController extends Controller
     public function store(Request $request)
     {
         // create a list of possible statuses
-        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED . "," . PurchaseOrder::PAID;
+        $statuses = $this->getPurchaseOrderStatuses();
         try {
             // validate the data to be stored is correct
             $request->validate([
@@ -113,7 +113,7 @@ class PurchaseOrderController extends Controller
     public function update(Request $request, $id)
     {
         // create a list of possible statuses
-        $statuses = PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED . "," . PurchaseOrder::PAID;
+        $statuses = $this->getPurchaseOrderStatuses();
         try {
             // validate that the incoming data is correct
             $request->validate([
@@ -146,4 +146,13 @@ class PurchaseOrderController extends Controller
         ]);
     }
 
+    /**
+     * Return comma-seperated string containing all purchase order statuses
+     *
+     * @return string
+     */
+    private function getPurchaseOrderStatuses(): string
+    {
+        return PurchaseOrder::PENDING . "," . PurchaseOrder::RECEIVED . "," . PurchaseOrder::CANCELLED . "," . PurchaseOrder::PAID;
+    }
 }

--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -54,7 +54,7 @@ class SaleController extends Controller
     public function store(Request $request)
     {
         // create a list of possible statuses
-        $statuses = Sale::PENDING . "," . Sale::RECEIVED . "," . Sale::PAID . "," . Sale::CANCELLED;
+        $statuses = Sale::PENDING . "," . Sale::SHIPPED . "," . Sale::PAID . "," . Sale::CANCELLED;
         $paymentTypes = Sale::VISA . "," . Sale::MASTER_CARD;
         try {
             // validate the data to be stored is correct
@@ -129,7 +129,7 @@ class SaleController extends Controller
     public function update(Request $request, $id)
     {
         // create a list of possible statuses
-        $statuses = Sale::PENDING . "," . Sale::RECEIVED . "," . Sale::PAID . "," . Sale::CANCELLED;
+        $statuses = Sale::PENDING . "," . Sale::SHIPPED . "," . Sale::PAID . "," . Sale::CANCELLED;
         $paymentTypes = Sale::VISA . "," . Sale::MASTER_CARD;
         try {
             // validate the data to be stored is correct

--- a/app/Http/Controllers/SaleController.php
+++ b/app/Http/Controllers/SaleController.php
@@ -54,8 +54,8 @@ class SaleController extends Controller
     public function store(Request $request)
     {
         // create a list of possible statuses
-        $statuses = Sale::PENDING . "," . Sale::SHIPPED . "," . Sale::PAID . "," . Sale::CANCELLED;
-        $paymentTypes = Sale::VISA . "," . Sale::MASTER_CARD;
+        $statuses = $this->getSaleStatuses();
+        $paymentTypes = $this->getPaymentTypes();
         try {
             // validate the data to be stored is correct
             $request->validate([
@@ -129,8 +129,8 @@ class SaleController extends Controller
     public function update(Request $request, $id)
     {
         // create a list of possible statuses
-        $statuses = Sale::PENDING . "," . Sale::SHIPPED . "," . Sale::PAID . "," . Sale::CANCELLED;
-        $paymentTypes = Sale::VISA . "," . Sale::MASTER_CARD;
+        $statuses = $this->getSaleStatuses();
+        $paymentTypes = $this->getPaymentTypes();
         try {
             // validate the data to be stored is correct
             $request->validate([
@@ -179,5 +179,26 @@ class SaleController extends Controller
     public function destroy($id)
     {
         //
+    }
+
+
+    /**
+     * Return comma-seperated string containing all sale statuses
+     *
+     * @return string
+     */
+    private function getSaleStatuses(): string
+    {
+        return Sale::PENDING . "," . Sale::SHIPPED . "," . Sale::CANCELLED . "," . Sale::PAID;
+    }
+
+    /**
+     * Return comma-seperated string containing all payment types
+     *
+     * @return string
+     */
+    private function getPaymentTypes(): string
+    {
+        return Sale::VISA . "," . Sale::MASTER_CARD;
     }
 }

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -19,7 +19,7 @@ class Sale extends Model
     protected $appends = ['cost'];
 
     public const PENDING = 'pending';
-    public const RECEIVED = 'received';
+    public const SHIPPED = 'shipped';
     public const PAID = 'paid';
     public const CANCELLED = 'cancelled';
 

--- a/tests/Feature/SaleTest.php
+++ b/tests/Feature/SaleTest.php
@@ -166,7 +166,7 @@ class SaleTest extends TestCase
 
         // proper update
         $updated = $this->actingAs($user)->put("/sale/$sale->id", [
-            'status' => "received",
+            'status' => "shipped",
             'payment_type' => 'Master Card',
             'card_number' => '1234123466669999',
             'price' => '69.99',
@@ -174,7 +174,7 @@ class SaleTest extends TestCase
         $updatedData = $updated->getOriginalContent();
         $updated->assertStatus(200);
         $this->assertNotEquals($sale, $updatedData['data']);
-        $this->assertEquals("received", $updatedData['data']->status);
+        $this->assertEquals("shipped", $updatedData['data']->status);
         $this->assertNotEquals($sale->card_number, $updatedData['data']->card_number);
         $this->assertEquals("Master Card", $updatedData['data']->payment_type);
         $this->assertEquals("69.99", $updatedData['data']->price);
@@ -183,7 +183,7 @@ class SaleTest extends TestCase
         $updated = $this->actingAs($user)->put("/sale/$sale->id", [
             'status' => 'still not here yet',
         ]);
-        $this->assertEquals("received", $updatedData['data']->status);
+        $this->assertEquals("shipped", $updatedData['data']->status);
 
 
         // improper update, invalid payment type


### PR DESCRIPTION
## Description
[CYC-156](https://soen390team13.atlassian.net/browse/CYC-156?atlOrigin=eyJpIjoiYzgxZDg0MzkyZmE5NDZjN2FjN2M2Yzg0MDNlNzRjMTYiLCJwIjoiaiJ9)
Closes #161 
Refactoring the `statuses` attribute for  `sale` and `purchaseOrder`

## Changes
- Changed Sale status `received` to `shipped`
- Added missing `paid` status to `PurchaseOrderController` functions
- Updated appropriate references to `Sale` `status` in `SaleTests`