### PR TITLE
CYC-156 Fix hard coded date in purchase order tests

### DIFF
--- a/tests/Feature/PurchaseOrderTest.php
+++ b/tests/Feature/PurchaseOrderTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature;
 
 use App\Models\PurchaseOrder;
 use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
@@ -21,7 +23,7 @@ class PurchaseOrderTest extends TestCase
         $redirected = $this->post('/purchase-order', [
             'supplier_id' => "1",
             'status' => "pending",
-            'delivery_date' => "2021-04-05",
+            'delivery_date' =>  Carbon::make('tomorrow'),
         ]);
 
         $redirected->assertStatus(302);
@@ -33,7 +35,7 @@ class PurchaseOrderTest extends TestCase
         $proper = $this->actingAs($user)->post('/purchase-order', [
             'supplier_id' => "1",
             'status' => "pending",
-            'delivery_date' => "2021-04-05",
+            'delivery_date' => Carbon::make('tomorrow'),
         ]);
 
         // Did we succeed?
@@ -47,7 +49,7 @@ class PurchaseOrderTest extends TestCase
         $improper = $this->actingAs($user)->post('/purchase-order', [
             'supplier_id' => "1",
             'status' => "not here yet",
-            'delivery_date' => "2021-04-05",
+            'delivery_date' =>  Carbon::make('tomorrow'),
         ]);
         $improperData = $improper->getOriginalContent();
 
@@ -60,7 +62,7 @@ class PurchaseOrderTest extends TestCase
         $improper = $this->actingAs($user)->post('/purchase-order', [
             'supplier_id' => "1",
             'status' => "pending",
-            'delivery_date' => "2020-04-05",
+            'delivery_date' =>  Carbon::make('-2 days'),
         ]);
         $improperData = $improper->getOriginalContent();
 
@@ -80,7 +82,7 @@ class PurchaseOrderTest extends TestCase
         $purchaseOrder = PurchaseOrder::create([
             'supplier_id' => "1",
             'status' => "pending",
-            'delivery_date' => "2021-04-05",
+            'delivery_date' =>  Carbon::make('tomorrow'),
         ]);
 
         // make sure we're redirected
@@ -96,7 +98,7 @@ class PurchaseOrderTest extends TestCase
         $updated = $this->actingAs($user)->put("/purchase-order/$purchaseOrder->id", [
             'supplier_id' => "2",
             'status' => "received",
-            'delivery_date' => "2021-04-18 12:30:00",
+            'delivery_date' =>  Carbon::make('tomorrow'),
         ]);
         $updatedData = $updated->getOriginalContent();
 
@@ -104,7 +106,7 @@ class PurchaseOrderTest extends TestCase
         $this->assertNotEquals($purchaseOrder, $updatedData['data']);
         $this->assertEquals("2", $updatedData['data']->supplier_id);
         $this->assertEquals("received", $updatedData['data']->status);
-        $this->assertEquals("2021-04-18 12:30:00", $updatedData['data']->delivery_date);
+        $this->assertEquals( Carbon::make('tomorrow'), $updatedData['data']->delivery_date);
 
 
         // improper update, invalid status
@@ -118,7 +120,7 @@ class PurchaseOrderTest extends TestCase
         $updated = $this->actingAs($user)->put("/purchase-order/$purchaseOrder->id", [
             'delivery_date' => "2020-04-18",
         ]);
-        $this->assertEquals($purchaseOrder->delivery_date,"2021-04-05");
+        $this->assertEquals($purchaseOrder->delivery_date, Carbon::make('tomorrow'));
     }
 
     public function test_purchase_orders_can_be_indexed()


### PR DESCRIPTION
## Description
See [CYC-156](https://soen390team13.atlassian.net/browse/CYC-156)

Fixes hard coded dates in the purchase order test.