### PR TITLE
CYC-156 Move stringToArray helper method to base Controller class

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,4 +10,17 @@ use Illuminate\Routing\Controller as BaseController;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    /**
+     * Converts a comma separated string to an array
+     *
+     * @param $input
+     * @return array
+     */
+    protected function stringToArray($input) : array
+    {
+        // convert a string to an array by splitting it on "," or casting it to an array
+        return is_string($input) ? explode(',', str_replace(" ", "", $input))
+            : (array) $input;
+    }
 }

--- a/app/Http/Controllers/MaterialController.php
+++ b/app/Http/Controllers/MaterialController.php
@@ -123,18 +123,4 @@ class MaterialController extends Controller
             'data' => $assembly->refresh()->materials
         ]);
     }
-
-
-    /**
-     * Transforms a comma seperated list of IDs into an array cleanly
-     *
-     * @param $input
-     * @return array
-     */
-    private function stringToArray($input) : array
-    {
-        // detect if the input is a string, if it is split it into an array on "," otherwise cast it to an array
-        return is_string($input) ? explode(',', str_replace(" ", "", $input))
-            : (array) $input;
-    }
 }

--- a/app/Http/Controllers/PurchaseOrderItemController.php
+++ b/app/Http/Controllers/PurchaseOrderItemController.php
@@ -45,14 +45,8 @@ class PurchaseOrderItemController extends Controller
             $purchaseOrder = PurchaseOrder::findOrFail($id);
         }
 
-        $itemIds = $request->item_ids;
-
-        // transform the
-        if (is_string($itemIds)) {
-            $itemIds = trim($itemIds, " ,");
-            $itemIds = Str::contains($itemIds, ",") ? explode(",", $itemIds) : [$itemIds];
-        }
-
+        // Get item ids from request data and parse into array
+        $itemIds = $this->stringToArray($request->item_ids);
 
         // attach the items to the order and save
         $purchaseOrder->order_items()->sync($itemIds);

--- a/app/Http/Controllers/UserRoleController.php
+++ b/app/Http/Controllers/UserRoleController.php
@@ -52,16 +52,4 @@ class UserRoleController extends Controller
         ]);
     }
 
-    /**
-     * Converts a comma separated string to an array
-     *
-     * @param $input
-     * @return array
-     */
-    private function stringToArray($input) : array
-    {
-        // convert a string to an array by splitting it on "," or casting it to an array
-        return is_string($input) ? explode(',', str_replace(" ", "", $input))
-            : (array) $input;
-    }
 }

--- a/tests/Feature/PurchaseOrderTest.php
+++ b/tests/Feature/PurchaseOrderTest.php
@@ -12,6 +12,8 @@ use Tests\TestCase;
 
 class PurchaseOrderTest extends TestCase
 {
+    use DatabaseTransactions;
+
     /**
      *
      * @test


### PR DESCRIPTION
## Description
Refactors Controller base class to include stringToArray method taken from UserRoleController and implements the helper method in PurchaseOrderItemController

## Changes
- Removes stringToArray from UserRoleController
- Removes stringToArray from MaterialController
- Adds stringToArray to Controller base class
- Modifies PurchaseOrderItemController to use new helper method
- Adds `use DatabaseTransactions;` to PurchaseOrderTest
