### PR TITLE
Add route that allows for filtering materials

### DIFF
--- a/app/Http/Controllers/AvailableMaterialController.php
+++ b/app/Http/Controllers/AvailableMaterialController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\InventoryItem;
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Builder;
+
+class AvailableMaterialController extends Controller
+{
+    /**
+     * Display a listing of the inventory items that are valid for attaching as a material to item_id.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index(Request $request)
+    {
+        $itemId = $request->item_id;
+        $assembly = InventoryItem::with('materials')->findOrFail($itemId);
+
+        return response([
+            'success' => true,
+            'data' => InventoryItem::whereNotIn('id', $assembly->materials->pluck('id')->push($itemId))->get()
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AvailableMaterialController;
 use App\Http\Controllers\SaleController;
 use App\Http\Controllers\InventoryItemController;
 use App\Http\Controllers\MaterialController;
@@ -51,10 +52,14 @@ Route::post('/inventory', [InventoryItemController::class, "store"])->middleware
 Route::put('/inventory/{id}', [InventoryItemController::class, "update"])->middleware(['auth']);
 Route::delete('/inventory/{id}', [InventoryItemController::class, "destroy"])->middleware(['auth']);
 
+Route::get('/materials/available', [AvailableMaterialController::class, "index"])->middleware(['auth']);
+
 Route::get('/materials', [MaterialController::class, "index"])->middleware(['auth']);
 Route::post('/materials', [MaterialController::class, "store"])->middleware(['auth']);
 Route::get('/materials/{id}', [MaterialController::class, "show"])->middleware(['auth']);
 Route::put('/materials/{id}', [MaterialController::class, "update"])->middleware(['auth']);
+
+
 
 Route::post('/user/roles', [UserRoleController::class, 'store'])->middleware(['auth']);
 Route::delete('/user/roles', [UserRoleController::class, 'destroy'])->middleware(['auth']);

--- a/tests/Feature/AvailbleMaterialTest.php
+++ b/tests/Feature/AvailbleMaterialTest.php
@@ -4,12 +4,15 @@ namespace Tests\Feature;
 
 use App\Models\InventoryItem;
 use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class AvailbleMaterialTest extends TestCase
 {
+    use DatabaseTransactions;
+    
     /**
      * A basic feature test example.
      *

--- a/tests/Feature/AvailbleMaterialTest.php
+++ b/tests/Feature/AvailbleMaterialTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\InventoryItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class AvailbleMaterialTest extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function test_available_materials_is_filtered_properly()
+    {
+        // attach some materials to Item 1
+        InventoryItem::find(1)->materials()->sync([2, 3, 4]);
+
+        $user = User::first();
+        $response = $this->actingAs($user)->get('/materials/available?item_id=1');
+
+        $response->assertStatus(200);
+        $responseData = $response->getOriginalContent();
+
+        $this->assertEmpty(array_intersect([1, 2, 3, 4], $responseData['data']->pluck('id')->toArray()));
+    }
+}


### PR DESCRIPTION
Closes #126 
Creates a different route that lists all valid materials for a given `InventoryItem`

## Changes
- Add new `AvailableMaterialController`
  - Add function that filters Items to non attached materials
- Add route `/materials/available` to call added function

### Docs

|  Endpoint | Parameters | Returns |
| ---- | --- | --- |
| `/materials/available` | `item_id`: ID of the given `InventoryItem` that you want to filter by | Success status, Array of valid inventory Items | 