### PR TITLE
CYC-157 Add payment delay to supplier

### DIFF
--- a/app/Models/Supplier.php
+++ b/app/Models/Supplier.php
@@ -12,6 +12,23 @@ class Supplier extends Model
 
     protected $guarded = ['id'];
 
+    /**
+     * Constant indicating a supplier must pay after 60 days
+     */
+    public const DELAY_60 = 60;
+
+    /**
+     * Constant indicating a supplier must pay after 30 days
+     */
+    public const DELAY_30 = 30;
+
+    /**
+     * Constant indicating a supplier may pay immediately
+     */
+    public const DELAY_NONE = 0;
+
+
+
     public function inventory_items() : HasMany
     {
         return $this->hasMany(InventoryItem::class);

--- a/database/factories/SupplierFactory.php
+++ b/database/factories/SupplierFactory.php
@@ -21,8 +21,10 @@ class SupplierFactory extends Factory
      */
     public function definition()
     {
+        $delays = [Supplier::DELAY_60, Supplier::DELAY_30, Supplier::DELAY_NONE];
         return [
             'name' => $this->faker->words(2, true),
+            'payment_delay' => $delays[$this->faker->numberBetween(0, 2)],
             'partnership_start_date' => $this->faker->dateTimeBetween("-2 years", "now"),
             'partnership_end_date' => $this->faker->dateTimeBetween("now", "+5 years")
         ];

--- a/database/migrations/2021_04_07_042313_add_payment_delay_to_suppliers_table.php
+++ b/database/migrations/2021_04_07_042313_add_payment_delay_to_suppliers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPaymentDelayToSuppliersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('suppliers', function (Blueprint $table) {
+            // can be either 60, 30, or 0
+            $table->integer('payment_delay')->default(0)->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('suppliers', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
## Description
Closes #175 
See [CYC-157](https://soen390team13.atlassian.net/browse/CYC-157) 

Adds a `payment_delay` property to suppliers that tells the user when a supplier must pay.

## Changes
- add migration to add field
- add consts to `Supplier` model
- update factory to choose random delay for each supplier

_nb: _ this PR is quite small, and is needed now so i will be self merging this. 