### PR TITLE
CYC-138 Add cost accessor to PurchaseOrder

### DIFF
--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -26,6 +26,7 @@ class PurchaseOrder extends Model
 
     public function getCostAttribute()
     {
+        // return a new collection of item cost * order quantity, then sum each value in that array for total cost
         return round($this->order_items->map(function ($orderable) {
             return $orderable->cost*$orderable->pivot->quantity;
         })->sum(), 2);

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -17,8 +17,15 @@ class PurchaseOrder extends Model
 
     protected $guarded = ['id'];
 
+    protected $appends = ['cost'];
+
     public function order_items() : MorphToMany
     {
         return $this->morphToMany(InventoryItem::class, 'orderable')->withPivot('quantity');
+    }
+
+    public function getCostAttribute()
+    {
+        return round($this->order_items->pluck('cost')->sum(), 2);
     }
 }

--- a/app/Models/PurchaseOrder.php
+++ b/app/Models/PurchaseOrder.php
@@ -26,6 +26,8 @@ class PurchaseOrder extends Model
 
     public function getCostAttribute()
     {
-        return round($this->order_items->pluck('cost')->sum(), 2);
+        return round($this->order_items->map(function ($orderable) {
+            return $orderable->cost*$orderable->pivot->quantity;
+        })->sum(), 2);
     }
 }

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -34,7 +34,9 @@ class Sale extends Model
 
     public function getCostAttribute()
     {
-        return round(collect($this->order_items->pluck('cost'))->sum(), 2);
+        return round($this->order_items->map(function ($orderable) {
+            return $orderable->cost*$orderable->pivot->quantity;
+        })->sum(), 2);
     }
 
     public function setCardNumberAttribute()

--- a/app/Models/Sale.php
+++ b/app/Models/Sale.php
@@ -34,6 +34,7 @@ class Sale extends Model
 
     public function getCostAttribute()
     {
+        // return a new collection of item cost * sale quantity, then sum each value in that array for total cost
         return round($this->order_items->map(function ($orderable) {
             return $orderable->cost*$orderable->pivot->quantity;
         })->sum(), 2);

--- a/tests/Feature/PurchaseOrderTest.php
+++ b/tests/Feature/PurchaseOrderTest.php
@@ -157,6 +157,8 @@ class PurchaseOrderTest extends TestCase
         $shown->assertStatus(200);
         $this->assertTrue($shownData['success']);
         $orderA = PurchaseOrder::find(1);
+        // force the loading of cost attribute
+        $orderA->cost;
         $this->assertEquals($orderA, $shownData['data']);
     }
 }


### PR DESCRIPTION
## Description
Closes #178 
See [CYC-138](https://soen390team13.atlassian.net/browse/CYC-138)

Add a dynamically calculated accessor to the purchase order that sums the cost of the items attached to the purchase order