### PR TITLE
CYC-156 Add foreign key cascades to prevent need for pre-deletions

### DIFF
--- a/database/migrations/2021_04_07_213152_update_foreign_key_cascades.php
+++ b/database/migrations/2021_04_07_213152_update_foreign_key_cascades.php
@@ -3,6 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 class UpdateForeignKeyCascades extends Migration
 {
@@ -13,6 +14,11 @@ class UpdateForeignKeyCascades extends Migration
      */
     public function up()
     {
+        // if we're in a sqlite (aka CI/CD container) database, this wont work so skip.
+        if (config('database.default') == 'sqlite') {
+            return;
+        }
+
         Schema::table('orderables', function (Blueprint $table) {
             $table->dropForeign('orderables_inventory_item_id_foreign');
 

--- a/database/migrations/2021_04_07_213152_update_foreign_key_cascades.php
+++ b/database/migrations/2021_04_07_213152_update_foreign_key_cascades.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateForeignKeyCascades extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('orderables', function (Blueprint $table) {
+            $table->dropForeign('orderables_inventory_item_id_foreign');
+
+            $table->foreign('inventory_item_id')
+                ->references('id')
+                ->on('inventory_items')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+        });
+
+        Schema::table('inventory_items', function (Blueprint $table) {
+            $table->dropForeign('inventory_items_supplier_id_foreign');
+
+            $table->foreign('supplier_id')
+                ->references('id')
+                ->on('suppliers')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
## Description
Closes #180 
See [CYC-156](https://soen390team13.atlassian.net/browse/CYC-156)

Adds a cascade on delete and update to certain foreign keys, thus meaning associated records are deleted when needed, automatically, saving this from being needed to be performed in other parts of the code.

_nb:_ This is a very small change so i'll be self merging this