### PR TITLE
CYC-163 Fix Observer and Date format issues

### DIFF
--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -67,7 +67,7 @@ class SupplierController extends Controller
         ]);
 
         $params['partnership_start_date'] = Carbon::make($params['partnership_start_date']);
-        $params['partnership_end_date'] = Carbon::make($params['partnership_end_date']);
+        $params['partnership_end_date'] = Carbon::make($params['partnership_end_date'] ?? null);
 
         // create the supplier
         $supplier = Supplier::create($params);
@@ -127,7 +127,7 @@ class SupplierController extends Controller
         ]);
 
         $params['partnership_start_date'] = Carbon::make($params['partnership_start_date']);
-        $params['partnership_end_date'] = Carbon::make($params['partnership_end_date']);
+        $params['partnership_end_date'] = Carbon::make($params['partnership_end_date'] ?? null);
 
         // update the supplier
         $supplier->update($params);

--- a/app/Http/Controllers/SupplierController.php
+++ b/app/Http/Controllers/SupplierController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Supplier;
+use Carbon\Carbon;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Http\Request;
 
@@ -65,6 +66,9 @@ class SupplierController extends Controller
             "partnership_end_date",
         ]);
 
+        $params['partnership_start_date'] = Carbon::make($params['partnership_start_date']);
+        $params['partnership_end_date'] = Carbon::make($params['partnership_end_date']);
+
         // create the supplier
         $supplier = Supplier::create($params);
         $supplier->save();
@@ -121,6 +125,9 @@ class SupplierController extends Controller
             "partnership_start_date",
             "partnership_end_date",
         ]);
+
+        $params['partnership_start_date'] = Carbon::make($params['partnership_start_date']);
+        $params['partnership_end_date'] = Carbon::make($params['partnership_end_date']);
 
         // update the supplier
         $supplier->update($params);

--- a/app/Observers/PurchaseOrderObserver.php
+++ b/app/Observers/PurchaseOrderObserver.php
@@ -5,20 +5,23 @@ namespace App\Observers;
 use App\Models\InventoryItem;
 use App\Models\OrderItem;
 use App\Models\PurchaseOrder;
+use Carbon\Carbon;
 
 class PurchaseOrderObserver
 {
     /**
-     * Handle the PurchaseOrder "updated" event.
+     * Handle the PurchaseOrder "updating" event.
      *
      * @param  \App\Models\PurchaseOrder  $purchaseOrder
      * @return void
      */
-    public function updated(PurchaseOrder $purchaseOrder)
+    public function updating(PurchaseOrder $purchaseOrder)
     {
         //check that status is received
         if ($purchaseOrder->status == PurchaseOrder::RECEIVED)
         {
+            $purchaseOrder->delivery_date = Carbon::now();
+
             //Get the order items corresponding to the PurchaseOrder
             $orderItems = OrderItem::where("orderable_id", $purchaseOrder->id)->get();
 

--- a/app/Observers/SaleObserver.php
+++ b/app/Observers/SaleObserver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Sale;
+
+class SaleObserver
+{
+    /**
+     * Handle the Sale "updating" event.
+     *
+     * @param  \App\Models\Sale  $sale
+     * @return void
+     */
+    public function updating(Sale $sale)
+    {
+        if ($sale->status == Sale::PAID) {
+            $sale->delivery_date = now();
+
+            foreach ($sale->order_items as $item) {
+                $item->stock = $item->stock - $item->pivot->quantity;
+                $item->save();
+            }
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -4,8 +4,10 @@ namespace App\Providers;
 
 use App\Models\InventoryItem;
 use App\Models\PurchaseOrder;
+use App\Models\Sale;
 use App\Observers\InventoryItemObserver;
 use App\Observers\PurchaseOrderObserver;
+use App\Observers\SaleObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
@@ -33,5 +35,6 @@ class EventServiceProvider extends ServiceProvider
     {
         PurchaseOrder::observe(PurchaseOrderObserver::class);
         InventoryItem::observe(InventoryItemObserver::class);
+        Sale::observe(SaleObserver::class);
     }
 }

--- a/tests/Feature/PurchaseOrderItemTest.php
+++ b/tests/Feature/PurchaseOrderItemTest.php
@@ -23,7 +23,7 @@ class PurchaseOrderItemTest extends TestCase
     public function test_items_can_be_updated_with_array()
     {
         $user = User::first();
-        $attached = $this->actingAs($user)->put('/purchase-order/orderables/1', [
+        $attached = $this->actingAs($user)->post('/purchase-order/orderables/1', [
             'item_ids' => [19, 20]
         ]);
 
@@ -50,7 +50,7 @@ class PurchaseOrderItemTest extends TestCase
     public function test_items_can_be_updated_with_string()
     {
         $user = User::first();
-        $attached = $this->actingAs($user)->put('/purchase-order/orderables/1', [
+        $attached = $this->actingAs($user)->post('/purchase-order/orderables/1', [
             'item_ids' => "17,18"
         ]);
 

--- a/tests/Feature/PurchaseOrderTest.php
+++ b/tests/Feature/PurchaseOrderTest.php
@@ -94,13 +94,12 @@ class PurchaseOrderTest extends TestCase
 
         $redirected->assertStatus(302);
 
-
         $user = User::first();
         // proper update, supplier partnership end date does not precede partnership start date
         $updated = $this->actingAs($user)->put("/purchase-order/$purchaseOrder->id", [
             'supplier_id' => "2",
             'status' => "received",
-            'delivery_date' =>  Carbon::make('tomorrow'),
+            'delivery_date' =>  Carbon::make('tomorrow')->format('Y-m-d H:i:s'),
         ]);
         $updatedData = $updated->getOriginalContent();
 
@@ -108,7 +107,8 @@ class PurchaseOrderTest extends TestCase
         $this->assertNotEquals($purchaseOrder, $updatedData['data']);
         $this->assertEquals("2", $updatedData['data']->supplier_id);
         $this->assertEquals("received", $updatedData['data']->status);
-        $this->assertEquals( Carbon::make('tomorrow'), $updatedData['data']->delivery_date);
+        // date is "now" because the status is received, and thus will be auto updated by the observer
+        $this->assertEquals(now()->format('Y-m-d H:i:s'), $updatedData['data']->delivery_date);
 
 
         // improper update, invalid status

--- a/tests/Feature/SupplierTest.php
+++ b/tests/Feature/SupplierTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Supplier;
 use App\Models\InventoryItem;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
@@ -174,7 +175,7 @@ class SupplierTest extends TestCase
         $updated->assertStatus(200);
         $this->assertNotEquals($testSupplier, $updatedData['data']);
         $this->assertEquals("test supplier 2.0", $updatedData['data']->name);
-        $this->assertEquals("2021-03-16 00:00:00", $updatedData['data']->partnership_start_date);
+        $this->assertEquals(Carbon::make("2021-03-16"), Carbon::make($updatedData['data']->partnership_start_date));
     }
 
 }

--- a/tests/Feature/SupplierTest.php
+++ b/tests/Feature/SupplierTest.php
@@ -95,7 +95,7 @@ class SupplierTest extends TestCase
         $properData = $proper->getOriginalContent();
         $this->assertTrue($properData['success']);
         $this->assertEquals($suppliersBefore + 1, Supplier::count());
-        
+
 
         $suppliersBefore = Supplier::count();
         // Try proper inputs; name, partnership start date and end date

--- a/tests/Feature/SupplierTest.php
+++ b/tests/Feature/SupplierTest.php
@@ -174,7 +174,7 @@ class SupplierTest extends TestCase
         $updated->assertStatus(200);
         $this->assertNotEquals($testSupplier, $updatedData['data']);
         $this->assertEquals("test supplier 2.0", $updatedData['data']->name);
-        $this->assertEquals("2021-03-16", $updatedData['data']->partnership_start_date);
+        $this->assertEquals("2021-03-16 00:00:00", $updatedData['data']->partnership_start_date);
     }
 
 }


### PR DESCRIPTION
## Description
Closes #186 
Closes #160
See [CYC-163](https://soen390team13.atlassian.net/browse/CYC-163)

Fixes improper date time formatting when adding a supplier via the create and update endpoints by casting dates to a `Carbon` datetime object

Adds a `SaleObserver` that automatically adjusts the delivery date of a paid sale as well as changing quantities upon sale of an object.

Fixes the `PurchaseOrderObserver` to change the delivery date to the current time when an object is delivered.

## How to test
1. Login and ensure that a vendor can be created via the Add vendor button
2. Attempt to complete a Sale via the Sales interface
3. Change the status of a purchase order to `PurchaseOrder::RECEIVED` via tinker (the interface does not currently allow this.)